### PR TITLE
enhanced github action (apt-get update is now necessary)

### DIFF
--- a/.github/workflows/coding_check.yml
+++ b/.github/workflows/coding_check.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   pep8_check:
-    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
+    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
     - name: install dependencies for PEP 8 code style check (ubuntu packages)
-      run: sudo apt install pep8 pylint3
+      run: sudo apt-get install pep8 pylint3
     - name: check PEP 8 code style
       run: pep8 --show-source --show-pep8 --statistics $(find -name "*.py")
     - name: run pylint


### PR DESCRIPTION
Due to a change in the ubuntu github action (see actions/virtual-environments#4136) we need to do a `apt-get update` before installing packages.
